### PR TITLE
Add checksum to check gradle artifacts after downloading

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionSha256Sum=b13f5d97f08000996bf12d9dd70af3f2c6b694c2c663ab1b545e9695562ad1ee
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The PR does
1. updates gradle to 6.9.1 (latest 6.x)
2. adds `distributionSha256Sum` (checksum is taken from https://gradle.org/release-checksums/)