### PR TITLE
Return ACLs from `AivenAclAuthorizerV2`

### DIFF
--- a/checkstyle/checkstyle-suppressions.xml
+++ b/checkstyle/checkstyle-suppressions.xml
@@ -17,4 +17,7 @@
     <suppress checks="MethodLength" files="AivenAclAuthorizerTest.java"/>
     <suppress checks="ClassFanOutComplexity" files="AivenAclAuthorizerV2Test.java"/>
     <suppress checks="CyclomaticComplexity" files="LegacyOperationNameFormatter.java" />
+
+    <!-- This is legit, it's just big switch, justified in this case -->
+    <suppress checks="CyclomaticComplexity" files="OperationNameFormatter.java" />
 </suppressions>

--- a/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerConfig.java
+++ b/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerConfig.java
@@ -30,6 +30,7 @@ public final class AivenAclAuthorizerConfig extends AbstractConfig {
     private static final String AUDITOR_CLASS_NAME_CONF = "aiven.acl.authorizer.auditor.class.name";
     private static final String LOG_DENIALS_CONF = "aiven.acl.authorizer.log.denials";
     private static final String CONFIG_REFRESH_CONF = "aiven.acl.authorizer.config.refresh.interval";
+    private static final String LIST_ACLS_ENABLED_CONF = "aiven.acl.authorizer.list.acls.enabled";
 
     public AivenAclAuthorizerConfig(final Map<?, ?> originals) {
         super(configDef(), originals);
@@ -61,6 +62,12 @@ public final class AivenAclAuthorizerConfig extends AbstractConfig {
                 10_000,
                 ConfigDef.Importance.LOW,
                 "The interval between ACL reloads"
+            ).define(
+                LIST_ACLS_ENABLED_CONF,
+                ConfigDef.Type.BOOLEAN,
+                true,
+                ConfigDef.Importance.LOW,
+                "Whether to allow listing ACLs"
             );
     }
 
@@ -78,5 +85,9 @@ public final class AivenAclAuthorizerConfig extends AbstractConfig {
 
     public int configRefreshInterval() {
         return getInt(CONFIG_REFRESH_CONF);
+    }
+
+    public boolean listAclsEnabled() {
+        return getBoolean(LIST_ACLS_ENABLED_CONF);
     }
 }

--- a/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerV2.java
+++ b/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerV2.java
@@ -229,7 +229,7 @@ public class AivenAclAuthorizerV2 implements Authorizer {
     public final List<? extends CompletionStage<AclCreateResult>> createAcls(
         final AuthorizableRequestContext requestContext,
         final List<AclBinding> aclBindings) {
-        LOGGER.error("`createAcls` is not implemented");
+        LOGGER.warn("`createAcls` is not implemented");
         return List.of();
     }
 
@@ -237,15 +237,17 @@ public class AivenAclAuthorizerV2 implements Authorizer {
     public final List<? extends CompletionStage<AclDeleteResult>> deleteAcls(
         final AuthorizableRequestContext requestContext,
         final List<AclBindingFilter> aclBindingFilters) {
-        LOGGER.error("`deleteAcls` is not implemented");
+        LOGGER.warn("`deleteAcls` is not implemented");
         return List.of();
     }
 
     @Override
     public final Iterable<AclBinding> acls(final AclBindingFilter filter) {
         if (this.config.listAclsEnabled()) {
-            // Filtering is not supported yet.
-            return AclAivenToNativeConverter.convert(this.cacheReference.get().aclEntries());
+            return this.cacheReference.get().aclEntries().stream()
+                    .flatMap(acl -> AclAivenToNativeConverter.convert(acl).stream())
+                    .filter(filter::matches)
+                    .collect(Collectors.toList());
         } else {
             LOGGER.warn("Listing ACLs is disabled");
             return List.of();

--- a/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerV2.java
+++ b/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerV2.java
@@ -57,6 +57,7 @@ import io.aiven.kafka.auth.json.reader.AclJsonReader;
 import io.aiven.kafka.auth.json.reader.JsonReaderException;
 import io.aiven.kafka.auth.nameformatters.LegacyOperationNameFormatter;
 import io.aiven.kafka.auth.nameformatters.LegacyResourceTypeNameFormatter;
+import io.aiven.kafka.auth.nativeacls.AclAivenToNativeConverter;
 
 import kafka.network.RequestChannel.Session;
 import org.slf4j.Logger;
@@ -242,7 +243,12 @@ public class AivenAclAuthorizerV2 implements Authorizer {
 
     @Override
     public final Iterable<AclBinding> acls(final AclBindingFilter filter) {
-        LOGGER.error("`acls` is not implemented");
-        return List.of();
+        if (this.config.listAclsEnabled()) {
+            // Filtering is not supported yet.
+            return AclAivenToNativeConverter.convert(this.cacheReference.get().aclEntries());
+        } else {
+            LOGGER.warn("Listing ACLs is disabled");
+            return List.of();
+        }
     }
 }

--- a/src/main/java/io/aiven/kafka/auth/VerdictCache.java
+++ b/src/main/java/io/aiven/kafka/auth/VerdictCache.java
@@ -37,22 +37,18 @@ public class VerdictCache {
     public boolean get(final KafkaPrincipal principal,
                        final String operation,
                        final String resource) {
-        if (aclEntries != null) {
-            final String cacheKey = resource
-                + "|" + operation
-                + "|" + principal.getName()
-                + "|" + principal.getPrincipalType();
+        final String cacheKey = resource
+            + "|" + operation
+            + "|" + principal.getName()
+            + "|" + principal.getPrincipalType();
 
-            final Predicate<AivenAcl> matcher = aclEntry ->
-                aclEntry.check(principal.getPrincipalType(), principal.getName(), operation, resource);
-            return cache.computeIfAbsent(cacheKey, key -> aclEntries.stream().anyMatch(matcher));
-        } else {
-            return false;
-        }
+        final Predicate<AivenAcl> matcher = aclEntry ->
+            aclEntry.check(principal.getPrincipalType(), principal.getName(), operation, resource);
+        return cache.computeIfAbsent(cacheKey, key -> aclEntries.stream().anyMatch(matcher));
     }
 
     public List<AivenAcl> aclEntries() {
-        return aclEntries;
+        return List.copyOf(aclEntries);
     }
 
     public static VerdictCache create(final List<AivenAcl> aclEntries) {

--- a/src/main/java/io/aiven/kafka/auth/VerdictCache.java
+++ b/src/main/java/io/aiven/kafka/auth/VerdictCache.java
@@ -19,6 +19,7 @@ package io.aiven.kafka.auth;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
 
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
@@ -30,7 +31,7 @@ public class VerdictCache {
     private final Map<String, Boolean> cache = new ConcurrentHashMap<>();
 
     private VerdictCache(final List<AivenAcl> aclEntries) {
-        this.aclEntries = aclEntries;
+        this.aclEntries = new CopyOnWriteArrayList<>(aclEntries);
     }
 
     public boolean get(final KafkaPrincipal principal,
@@ -48,6 +49,10 @@ public class VerdictCache {
         } else {
             return false;
         }
+    }
+
+    public List<AivenAcl> aclEntries() {
+        return aclEntries;
     }
 
     public static VerdictCache create(final List<AivenAcl> aclEntries) {

--- a/src/main/java/io/aiven/kafka/auth/json/AivenAcl.java
+++ b/src/main/java/io/aiven/kafka/auth/json/AivenAcl.java
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
 
 import com.google.gson.annotations.SerializedName;
 
-public class  AivenAcl {
+public class AivenAcl {
     @SerializedName("principal_type")
     public final String principalType;
 

--- a/src/main/java/io/aiven/kafka/auth/json/AivenAcl.java
+++ b/src/main/java/io/aiven/kafka/auth/json/AivenAcl.java
@@ -24,19 +24,19 @@ import com.google.gson.annotations.SerializedName;
 
 public class  AivenAcl {
     @SerializedName("principal_type")
-    private final String principalType;
+    public final String principalType;
 
     @SerializedName("principal")
-    private final Pattern principalRe;
+    public final Pattern principalRe;
 
     @SerializedName("operation")
-    private final Pattern operationRe;
+    public final Pattern operationRe;
 
     @SerializedName("resource")
-    private final Pattern resourceRe;
+    public final Pattern resourceRe;
 
     @SerializedName("resource_pattern")
-    private final String resourceRePattern;
+    public final String resourceRePattern;
 
     public AivenAcl(final String principalType,
                     final String principal,

--- a/src/main/java/io/aiven/kafka/auth/nameformatters/OperationNameFormatter.java
+++ b/src/main/java/io/aiven/kafka/auth/nameformatters/OperationNameFormatter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nameformatters;
+
+import org.apache.kafka.common.acl.AclOperation;
+
+public class OperationNameFormatter {
+    public static AclOperation format(final String operation) {
+        switch (operation) {
+            case "Unknown":
+                return AclOperation.UNKNOWN;
+
+            case "Any":
+                return AclOperation.ANY;
+
+            case "All":
+                return AclOperation.ALL;
+
+            case "Read":
+                return AclOperation.READ;
+
+            case "Write":
+                return AclOperation.WRITE;
+
+            case "Create":
+                return AclOperation.CREATE;
+
+            case "Delete":
+                return AclOperation.DELETE;
+
+            case "Alter":
+                return AclOperation.ALTER;
+
+            case "Describe":
+                return AclOperation.DESCRIBE;
+
+            case "ClusterAction":
+                return AclOperation.CLUSTER_ACTION;
+
+            case "DescribeConfigs":
+                return AclOperation.DESCRIBE_CONFIGS;
+
+            case "AlterConfigs":
+                return AclOperation.ALTER_CONFIGS;
+
+            case "IdempotentWrite":
+                return AclOperation.IDEMPOTENT_WRITE;
+
+            default:
+                return AclOperation.UNKNOWN;
+        }
+    }
+}

--- a/src/main/java/io/aiven/kafka/auth/nameformatters/ResourceTypeNameFormatter.java
+++ b/src/main/java/io/aiven/kafka/auth/nameformatters/ResourceTypeNameFormatter.java
@@ -21,9 +21,6 @@ import org.apache.kafka.common.resource.ResourceType;
 public class ResourceTypeNameFormatter {
     public static ResourceType format(final String resourceType) {
         switch (resourceType) {
-            case "Unknown":
-                return ResourceType.UNKNOWN;
-
             case "Any":
                 return ResourceType.ANY;
 

--- a/src/main/java/io/aiven/kafka/auth/nameformatters/ResourceTypeNameFormatter.java
+++ b/src/main/java/io/aiven/kafka/auth/nameformatters/ResourceTypeNameFormatter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nameformatters;
+
+import org.apache.kafka.common.resource.ResourceType;
+
+public class ResourceTypeNameFormatter {
+    public static ResourceType format(final String resourceType) {
+        switch (resourceType) {
+            case "Unknown":
+                return ResourceType.UNKNOWN;
+
+            case "Any":
+                return ResourceType.ANY;
+
+            case "Topic":
+                return ResourceType.TOPIC;
+
+            case "Group":
+                return ResourceType.GROUP;
+
+            case "Cluster":
+                return ResourceType.CLUSTER;
+
+            case "TransactionalId":
+                return ResourceType.TRANSACTIONAL_ID;
+
+            case "DelegationToken":
+                return ResourceType.DELEGATION_TOKEN;
+
+            default:
+                return ResourceType.UNKNOWN;
+        }
+    }
+}

--- a/src/main/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverter.java
+++ b/src/main/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverter.java
@@ -38,7 +38,7 @@ public class AclAivenToNativeConverter {
         }
 
         for (final var operation : AclOperationsParser.parse(aivenAcl.operationRe.pattern())) {
-            final List<String> principals = AclPrincipalParser.parse(
+            final List<String> principals = AclPrincipalFormatter.parse(
                 aivenAcl.principalType, aivenAcl.principalRe.pattern()
             );
             for (final var principal : principals) {

--- a/src/main/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverter.java
+++ b/src/main/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nativeacls;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.kafka.common.acl.AccessControlEntry;
+import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclPermissionType;
+
+import io.aiven.kafka.auth.json.AivenAcl;
+
+public class AclAivenToNativeConverter {
+    public static Iterable<AclBinding> convert(final List<AivenAcl> aivenAcls) {
+        final List<AclBinding> result = new ArrayList<>();
+
+        for (final var aclEntry : aivenAcls) {
+            if (!Objects.equals(aclEntry.principalType, "User")) {
+                continue;
+            }
+
+            for (final var operation : AclOperationsParser.parse(aclEntry.operationRe.pattern())) {
+                List<String> principals = RegexParser.parse(aclEntry.principalRe.pattern());
+                if (principals == null) {
+                    principals = List.of(aclEntry.principalRe.pattern());
+                }
+                for (final var principal : principals) {
+                    final var accessControlEntry = new AccessControlEntry(
+                        principal, "*", operation, AclPermissionType.ALLOW);
+                    for (final var resourcePattern : ResourcePatternParser.parse(aclEntry.resourceRe.pattern())) {
+                        result.add(new AclBinding(resourcePattern, accessControlEntry));
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/io/aiven/kafka/auth/nativeacls/AclOperationsParser.java
+++ b/src/main/java/io/aiven/kafka/auth/nativeacls/AclOperationsParser.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nativeacls;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.acl.AclOperation;
+
+import io.aiven.kafka.auth.nameformatters.OperationNameFormatter;
+
+class AclOperationsParser {
+    // Visible for test
+    static Iterable<AclOperation> parse(final String operationPattern) {
+        if (operationPattern == null) {
+            return List.of();
+        }
+
+        if (operationPattern.equals("^.*$") || operationPattern.equals("^(.*)$")) {
+            return List.of(
+                AclOperation.READ,
+                AclOperation.WRITE,
+                AclOperation.CREATE,
+                AclOperation.DELETE,
+                AclOperation.ALTER,
+                AclOperation.DESCRIBE,
+                AclOperation.CLUSTER_ACTION,
+                AclOperation.DESCRIBE_CONFIGS,
+                AclOperation.ALTER_CONFIGS,
+                AclOperation.IDEMPOTENT_WRITE
+            );
+        }
+
+        final List<String> parsedOperationList = RegexParser.parse(operationPattern);
+        if (parsedOperationList == null) {
+            return List.of();
+        }
+        return parsedOperationList.stream()
+            .map(OperationNameFormatter::format)
+            .filter(o -> o != AclOperation.UNKNOWN)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/io/aiven/kafka/auth/nativeacls/AclOperationsParser.java
+++ b/src/main/java/io/aiven/kafka/auth/nativeacls/AclOperationsParser.java
@@ -23,7 +23,13 @@ import org.apache.kafka.common.acl.AclOperation;
 
 import io.aiven.kafka.auth.nameformatters.OperationNameFormatter;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 class AclOperationsParser {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AclOperationsParser.class);
+
     // Visible for test
     static Iterable<AclOperation> parse(final String operationPattern) {
         if (operationPattern == null) {
@@ -47,6 +53,7 @@ class AclOperationsParser {
 
         final List<String> parsedOperationList = RegexParser.parse(operationPattern);
         if (parsedOperationList == null) {
+            LOGGER.debug("Nothing parsed from operation {}", operationPattern);
             return List.of();
         }
         return parsedOperationList.stream()

--- a/src/main/java/io/aiven/kafka/auth/nativeacls/AclPrincipalFormatter.java
+++ b/src/main/java/io/aiven/kafka/auth/nativeacls/AclPrincipalFormatter.java
@@ -19,18 +19,18 @@ package io.aiven.kafka.auth.nativeacls;
 import java.util.List;
 import java.util.stream.Collectors;
 
-class AclPrincipalParser {
+class AclPrincipalFormatter {
     // Visible for test
     static List<String> parse(final String principalType, final String principalPattern) {
         if (principalType == null || principalPattern == null) {
             return List.of();
         }
-        if (principalPattern.contains(".*")) {
-            return List.of(principalType + ":*");
-        }
         List<String> principals = RegexParser.parse(principalPattern);
         if (principals == null) {
             principals = List.of(principalPattern);
+        }
+        if (principals.contains("(.*)") || principals.contains(".*")) {
+            return List.of(principalType + ":*");
         }
         return principals.stream()
             .map(p -> principalType + ":" + p)

--- a/src/main/java/io/aiven/kafka/auth/nativeacls/AclPrincipalParser.java
+++ b/src/main/java/io/aiven/kafka/auth/nativeacls/AclPrincipalParser.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nativeacls;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+class AclPrincipalParser {
+    // Visible for test
+    static List<String> parse(final String principalType, final String principalPattern) {
+        if (principalType == null || principalPattern == null) {
+            return List.of();
+        }
+        if (principalPattern.contains(".*")) {
+            return List.of(principalType + ":*");
+        }
+        List<String> principals = RegexParser.parse(principalPattern);
+        if (principals == null) {
+            principals = List.of(principalPattern);
+        }
+        return principals.stream()
+            .map(p -> principalType + ":" + p)
+            .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/auth/nativeacls/RegexParser.java
+++ b/src/main/java/io/aiven/kafka/auth/nativeacls/RegexParser.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 
 class RegexParser {
 
-    private static final Pattern PARSER_PATTERN = Pattern.compile("\\^\\(?(.*?)\\)?\\$");
+    private static final Pattern PARSER_PATTERN = Pattern.compile("(?<=^\\^)(.*?)(?=\\$$)");
 
     // Visible for test
     /**
@@ -44,7 +44,11 @@ class RegexParser {
             return null;
         }
 
-        final String group = matcher.group(1);
+        String group = matcher.group(0);
+        final int lastChar = group.length() - 1;
+        if (group.charAt(0) == '(' && group.charAt(lastChar) == ')') {
+            group = group.substring(1, lastChar);
+        }
         return Arrays.stream(group.split("\\|"))
             .filter(Predicate.not(String::isBlank))
             .collect(Collectors.toList());

--- a/src/main/java/io/aiven/kafka/auth/nativeacls/RegexParser.java
+++ b/src/main/java/io/aiven/kafka/auth/nativeacls/RegexParser.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nativeacls;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class RegexParser {
+
+    // Visible for test
+    /**
+     * Parses a regex pattern into a list.
+     * <br>
+     * For example, <code>^(AAA|BBB|CCC)$</code> results in <code>List("AAA", "BBB", "CCC")</code>,
+     * <code>^AAA$</code> results in <code>List("AAA")</code>. Unparsable strings results in {@code null}.
+     */
+    static List<String> parse(String pattern) {
+        if (pattern == null) {
+            return null;
+        }
+
+        // Remove regex pattern prefix and postfix.
+        if (!pattern.startsWith("^")) {
+            return null;
+        }
+        pattern = pattern.substring(1);
+        if (pattern.startsWith("(")) {
+            pattern = pattern.substring(1);
+        }
+
+        if (!pattern.endsWith("$")) {
+            return null;
+        }
+        pattern = pattern.substring(0, pattern.length() - 1);
+        if (pattern.endsWith(")")) {
+            pattern = pattern.substring(0, pattern.length() - 1);
+        }
+
+        if (pattern.equals("^(.*)$")) {
+            return null;
+        }
+
+        return Arrays.stream(pattern.split("\\|")).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/io/aiven/kafka/auth/nativeacls/ResourcePatternParser.java
+++ b/src/main/java/io/aiven/kafka/auth/nativeacls/ResourcePatternParser.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nativeacls;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourceType;
+
+class ResourcePatternParser {
+    // Visible for test
+    static Iterable<ResourcePattern> parse(final String resourcePattern) {
+        if (resourcePattern == null) {
+            return List.of();
+        }
+
+        if (resourcePattern.equals("^.*$") || resourcePattern.equals("^(.*)$")) {
+            final var resourcePatternNormalized = resourcePattern.equals("^(.*)$") ? "^.*$" : resourcePattern;
+            return List.of(
+                new ResourcePattern(ResourceType.TOPIC, resourcePatternNormalized, PatternType.LITERAL),
+                new ResourcePattern(ResourceType.GROUP, resourcePatternNormalized, PatternType.LITERAL),
+                new ResourcePattern(ResourceType.CLUSTER, resourcePatternNormalized, PatternType.LITERAL),
+                new ResourcePattern(ResourceType.TRANSACTIONAL_ID, resourcePatternNormalized, PatternType.LITERAL),
+                new ResourcePattern(ResourceType.DELEGATION_TOKEN, resourcePatternNormalized, PatternType.LITERAL)
+            );
+        }
+
+        final String[] parts = resourcePattern.split(":");
+        if (parts.length != 2) {
+            return List.of();
+        }
+
+        // Normalize and parse the left part.
+        final List<ResourceType> resourceTypes = parseResourceTypes(parts[0]);
+        if (resourceTypes == null) {
+            return List.of();
+        }
+
+        final List<String> resources = parseResources(parts[1]);
+        if (resources == null) {
+            return List.of();
+        }
+
+        final List<ResourcePattern> result = new ArrayList<>(resourceTypes.size() * resources.size());
+        for (final ResourceType resourceType : resourceTypes) {
+            for (final String resource : resources) {
+                result.add(
+                    new ResourcePattern(resourceType, resource, PatternType.LITERAL)
+                );
+            }
+        }
+        return result;
+    }
+
+    private static List<ResourceType> parseResourceTypes(String leftPart) {
+        if (!leftPart.startsWith("^")) {
+            return null;
+        }
+        if (leftPart.startsWith("^(")) {
+            leftPart = leftPart.substring(2);
+        } else {
+            leftPart = leftPart.substring(1);
+        }
+        if (leftPart.endsWith(")")) {
+            leftPart = leftPart.substring(0, leftPart.length() - 1);
+        }
+        leftPart = leftPart.trim();
+        if (leftPart.isEmpty()) {
+            return null;
+        }
+        return ResourceTypeParser.parse("^(" + leftPart + ")$");
+    }
+
+    private static List<String> parseResources(String rightPart) {
+        if (!rightPart.endsWith("$")) {
+            return null;
+        }
+        if (rightPart.endsWith(")$")) {
+            rightPart = rightPart.substring(0, rightPart.length() - 2);
+        } else {
+            rightPart = rightPart.substring(0, rightPart.length() - 1);
+        }
+        if (rightPart.startsWith("(")) {
+            rightPart = rightPart.substring(1);
+        }
+        rightPart = rightPart.trim();
+        if (rightPart.isEmpty()) {
+            return null;
+        }
+
+        return RegexParser.parse("^(" + rightPart + ")$");
+    }
+}

--- a/src/main/java/io/aiven/kafka/auth/nativeacls/ResourceTypeParser.java
+++ b/src/main/java/io/aiven/kafka/auth/nativeacls/ResourceTypeParser.java
@@ -17,7 +17,6 @@
 package io.aiven.kafka.auth.nativeacls;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.kafka.common.resource.ResourceType;
 
@@ -40,14 +39,6 @@ class ResourceTypeParser {
             );
         }
 
-        final List<String> parsedResourceTypeList = RegexParser.parse(resourceTypePattern);
-        if (parsedResourceTypeList == null) {
-            return List.of();
-        }
-
-        return parsedResourceTypeList.stream()
-            .map(ResourceTypeNameFormatter::format)
-            .filter(rt -> rt != ResourceType.UNKNOWN)
-            .collect(Collectors.toList());
+        return List.of(ResourceTypeNameFormatter.format(resourceTypePattern));
     }
 }

--- a/src/main/java/io/aiven/kafka/auth/nativeacls/ResourceTypeParser.java
+++ b/src/main/java/io/aiven/kafka/auth/nativeacls/ResourceTypeParser.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nativeacls;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.resource.ResourceType;
+
+import io.aiven.kafka.auth.nameformatters.ResourceTypeNameFormatter;
+
+class ResourceTypeParser {
+    // Visible for test
+    static List<ResourceType> parse(final String resourceTypePattern) {
+        if (resourceTypePattern == null) {
+            return List.of();
+        }
+
+        if (resourceTypePattern.equals("^.*$") || resourceTypePattern.equals("^(.*)$")) {
+            return List.of(
+                ResourceType.TOPIC,
+                ResourceType.GROUP,
+                ResourceType.CLUSTER,
+                ResourceType.TRANSACTIONAL_ID,
+                ResourceType.DELEGATION_TOKEN
+            );
+        }
+
+        final List<String> parsedResourceTypeList = RegexParser.parse(resourceTypePattern);
+        if (parsedResourceTypeList == null) {
+            return List.of();
+        }
+
+        return parsedResourceTypeList.stream()
+            .map(ResourceTypeNameFormatter::format)
+            .filter(rt -> rt != ResourceType.UNKNOWN)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/AivenAclAuthorizerConfigTest.java
+++ b/src/test/java/io/aiven/kafka/auth/AivenAclAuthorizerConfigTest.java
@@ -45,6 +45,7 @@ class AivenAclAuthorizerConfigTest {
         assertEquals("/test", config.getConfigFile().getAbsolutePath());
         assertEquals(NoAuditor.class, config.getAuditor().getClass());
         assertTrue(config.logDenials());
+        assertTrue(config.listAclsEnabled());
     }
 
     @Test
@@ -55,12 +56,14 @@ class AivenAclAuthorizerConfigTest {
         userActivityProps.put("aiven.acl.authorizer.auditor.aggregation.period", "123");
         userActivityProps.put("aiven.acl.authorizer.log.denials", "false");
         userActivityProps.put("aiven.acl.authorizer.config.refresh.interval", "10");
+        userActivityProps.put("aiven.acl.authorizer.list.acls.enabled", "false");
 
         var config = new AivenAclAuthorizerConfig(userActivityProps);
         assertEquals("/test", config.getConfigFile().getAbsolutePath());
         assertEquals(UserActivityAuditor.class, config.getAuditor().getClass());
         assertFalse(config.logDenials());
         assertEquals(10, config.configRefreshInterval());
+        assertFalse(config.listAclsEnabled());
 
         final Map<String, String> userActivityOpsProps = new HashMap<>();
         userActivityOpsProps.put("aiven.acl.authorizer.configuration", "/test");

--- a/src/test/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverterTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverterTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nativeacls;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.kafka.common.acl.AccessControlEntry;
+import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourceType;
+
+import io.aiven.kafka.auth.json.AivenAcl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AclAivenToNativeConverterTest {
+    @Test
+    public final void testConvertSimple() {
+        final var result = AclAivenToNativeConverter.convert(
+            List.of(new AivenAcl(
+                "User",
+                "^(test\\-user)$",
+                "^(Alter|AlterConfigs|Delete|Read|Write)$",
+                "^Topic:(xxx)$",
+                null
+            ))
+        );
+        final ResourcePattern resourcePattern = new ResourcePattern(ResourceType.TOPIC, "xxx", PatternType.LITERAL);
+        assertThat(result).containsExactly(
+            new AclBinding(
+                resourcePattern,
+                new AccessControlEntry("test\\-user", "*", AclOperation.ALTER, AclPermissionType.ALLOW)),
+            new AclBinding(
+                resourcePattern,
+                new AccessControlEntry("test\\-user", "*", AclOperation.ALTER_CONFIGS, AclPermissionType.ALLOW)),
+            new AclBinding(
+                resourcePattern,
+                new AccessControlEntry("test\\-user", "*", AclOperation.DELETE, AclPermissionType.ALLOW)),
+            new AclBinding(
+                resourcePattern,
+                new AccessControlEntry("test\\-user", "*", AclOperation.READ, AclPermissionType.ALLOW)),
+            new AclBinding(
+                resourcePattern,
+                new AccessControlEntry("test\\-user", "*", AclOperation.WRITE, AclPermissionType.ALLOW))
+        );
+    }
+
+    @Test
+    public final void testSuperadmin() {
+        final var result = AclAivenToNativeConverter.convert(
+            List.of(new AivenAcl(
+                "User",
+                "^(admin)$",
+                "^(.*)$",
+                "^(.*)$",
+                null
+            ))
+        );
+
+        final List<AclBinding> expected = new ArrayList<>();
+        final List<ResourceType> expectedResourceTypes = List.of(
+            ResourceType.TOPIC, ResourceType.GROUP, ResourceType.CLUSTER,
+            ResourceType.TRANSACTIONAL_ID, ResourceType.DELEGATION_TOKEN);
+        final List<AclOperation> expectedAclOperations = List.of(
+            AclOperation.READ, AclOperation.WRITE, AclOperation.CREATE,
+            AclOperation.DELETE, AclOperation.ALTER, AclOperation.DESCRIBE,
+            AclOperation.CLUSTER_ACTION, AclOperation.DESCRIBE_CONFIGS,
+            AclOperation.ALTER_CONFIGS, AclOperation.IDEMPOTENT_WRITE);
+        for (final var resourceType : expectedResourceTypes) {
+            for (final var aclOperation : expectedAclOperations) {
+                expected.add(new AclBinding(
+                    new ResourcePattern(resourceType, "^.*$", PatternType.LITERAL),
+                    new AccessControlEntry("admin", "*", aclOperation, AclPermissionType.ALLOW))
+                );
+            }
+        }
+        assertThat(result).containsAll(expected);
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/nativeacls/AclOperationsParserTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nativeacls/AclOperationsParserTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nativeacls;
+
+import org.apache.kafka.common.acl.AclOperation;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AclOperationsParserTest {
+    @Test
+    public final void parseAclOperationsSingle() {
+        assertThat(AclOperationsParser.parse("^Create$"))
+            .containsExactly(AclOperation.CREATE);
+    }
+
+    @Test
+    public final void parseAclOperationsSingleWithParens() {
+        assertThat(AclOperationsParser.parse("^(Create)$"))
+            .containsExactly(AclOperation.CREATE);
+    }
+
+    @Test
+    public final void parseAclOperationsMultiple() {
+        // List all possible here, apart from Unknown.
+        final String operationPattern = "^(Any|All|Read|Write|Create|Delete|Alter|Describe|"
+            + "ClusterAction|DescribeConfigs|AlterConfigs|IdempotentWrite)$";
+        assertThat(AclOperationsParser.parse(operationPattern))
+            .containsExactly(
+                AclOperation.ANY,
+                AclOperation.ALL,
+                AclOperation.READ,
+                AclOperation.WRITE,
+                AclOperation.CREATE,
+                AclOperation.DELETE,
+                AclOperation.ALTER,
+                AclOperation.DESCRIBE,
+                AclOperation.CLUSTER_ACTION,
+                AclOperation.DESCRIBE_CONFIGS,
+                AclOperation.ALTER_CONFIGS,
+                AclOperation.IDEMPOTENT_WRITE
+            );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"^(.*)$", "^.*$"})
+    public final void parseAclOperationsGlobalWildcard(final String value) {
+        assertThat(AclOperationsParser.parse(value))
+            .containsExactly(
+                AclOperation.READ,
+                AclOperation.WRITE,
+                AclOperation.CREATE,
+                AclOperation.DELETE,
+                AclOperation.ALTER,
+                AclOperation.DESCRIBE,
+                AclOperation.CLUSTER_ACTION,
+                AclOperation.DESCRIBE_CONFIGS,
+                AclOperation.ALTER_CONFIGS,
+                AclOperation.IDEMPOTENT_WRITE
+            );
+    }
+
+    @Test
+    public final void parseAclOperationsSingleUnknown() {
+        assertThat(AclOperationsParser.parse("^(Some)$"))
+            .isEmpty();
+    }
+
+    @Test
+    public final void parseAclOperationsNull() {
+        assertThat(AclOperationsParser.parse(null))
+            .isEmpty();
+    }
+
+    @Test
+    public final void parseAclOperationsMultipleWithUnknown() {
+        assertThat(AclOperationsParser.parse("^(Create|Describe|AlterConfigs|Some)$"))
+            .containsExactly(
+                AclOperation.CREATE,
+                AclOperation.DESCRIBE,
+                AclOperation.ALTER_CONFIGS);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "^(Create|Delete)",
+        "(Create|Delete)$",
+        "^(Create|Delete",
+        "Create|Delete)$"
+    })
+    public final void parseAclOperationsInvalid(final String pattern) {
+        assertThat(AclOperationsParser.parse(pattern))
+            .isEmpty();
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/nativeacls/AclPrincipalFormatterTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nativeacls/AclPrincipalFormatterTest.java
@@ -22,36 +22,42 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AclPrincipalParserTest {
+public class AclPrincipalFormatterTest {
 
     @Test
     public final void parseSinglePrincipal() {
-        assertThat(AclPrincipalParser.parse("User", "^username$"))
+        assertThat(AclPrincipalFormatter.parse("User", "^username$"))
             .containsExactly("User:username");
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"(.*)", "^(username|(.*))$"})
+    @ValueSource(strings = {"(.*)", ".*", "^(username|(.*))$", "^(username|.*)$"})
     public final void parseWildcardPrincipal(final String value) {
-        assertThat(AclPrincipalParser.parse("User", value))
+        assertThat(AclPrincipalFormatter.parse("User", value))
             .containsExactly("User:*");
     }
 
     @Test
+    public final void parseNotWildcard() {
+        assertThat(AclPrincipalFormatter.parse("User", "username.*"))
+            .containsExactly("User:username.*");
+    }
+
+    @Test
     public final void parseMultipleUsers() {
-        assertThat(AclPrincipalParser.parse("User", "^(user1|user2)$"))
+        assertThat(AclPrincipalFormatter.parse("User", "^(user1|user2)$"))
             .containsExactly("User:user1", "User:user2");
     }
 
     @Test
     public final void parseNullPrincipal() {
-        assertThat(AclPrincipalParser.parse("User", null))
+        assertThat(AclPrincipalFormatter.parse("User", null))
             .isEmpty();
     }
 
     @Test
     public final void parseNullPrincipalType() {
-        assertThat(AclPrincipalParser.parse(null, "^username$"))
+        assertThat(AclPrincipalFormatter.parse(null, "^username$"))
             .isEmpty();
     }
 

--- a/src/test/java/io/aiven/kafka/auth/nativeacls/AclPrincipalParserTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nativeacls/AclPrincipalParserTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nativeacls;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AclPrincipalParserTest {
+
+    @Test
+    public final void parseSinglePrincipal() {
+        assertThat(AclPrincipalParser.parse("User", "^username$"))
+            .containsExactly("User:username");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"(.*)", "^(username|(.*))$"})
+    public final void parseWildcardPrincipal(final String value) {
+        assertThat(AclPrincipalParser.parse("User", value))
+            .containsExactly("User:*");
+    }
+
+    @Test
+    public final void parseMultipleUsers() {
+        assertThat(AclPrincipalParser.parse("User", "^(user1|user2)$"))
+            .containsExactly("User:user1", "User:user2");
+    }
+
+    @Test
+    public final void parseNullPrincipal() {
+        assertThat(AclPrincipalParser.parse("User", null))
+            .isEmpty();
+    }
+
+    @Test
+    public final void parseNullPrincipalType() {
+        assertThat(AclPrincipalParser.parse(null, "^username$"))
+            .isEmpty();
+    }
+
+}

--- a/src/test/java/io/aiven/kafka/auth/nativeacls/RegexParserTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nativeacls/RegexParserTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nativeacls;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RegexParserTest {
+    @Test
+    public final void parseRegexListSingle() {
+        assertThat(RegexParser.parse("^AAA$"))
+            .containsExactly("AAA");
+    }
+
+    @Test
+    public final void parseRegexListSingleWithParens() {
+        assertThat(RegexParser.parse("^(AAA)$"))
+            .containsExactly("AAA");
+    }
+
+    @Test
+    public final void parseRegexListMultiple() {
+        assertThat(RegexParser.parse("^(AAA|BBB|CCC|DDD)$"))
+            .containsExactly("AAA", "BBB", "CCC", "DDD");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "^(AAA|BBB|CCC|DDD)",
+        "(AAA|BBB|CCC|DDD)$",
+        "^(AAA|BBB|CCC|DDD",
+        "AAA|BBB|CCC|DDD)$"
+    })
+    public final void parseRegexListInvalid(final String pattern) {
+        assertThat(RegexParser.parse(pattern))
+            .isNull();
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/nativeacls/RegexParserTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nativeacls/RegexParserTest.java
@@ -36,6 +36,18 @@ public class RegexParserTest {
     }
 
     @Test
+    public final void parseParenthesis() {
+        assertThat(RegexParser.parse("^qwe)$"))
+            .containsExactly("qwe)");
+    }
+
+    @Test
+    public final void parseNestedRegex() {
+        assertThat(RegexParser.parse("^(AAA|^(BB)$)$"))
+            .containsExactly("AAA", "^(BB)$");
+    }
+
+    @Test
     public final void parseRegexListMultiple() {
         assertThat(RegexParser.parse("^(AAA|BBB|CCC|DDD)$"))
             .containsExactly("AAA", "BBB", "CCC", "DDD");

--- a/src/test/java/io/aiven/kafka/auth/nativeacls/ResourcePatternParserTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nativeacls/ResourcePatternParserTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2022 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nativeacls;
+
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourceType;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResourcePatternParserTest {
+    @ParameterizedTest
+    @ValueSource(strings = {"^(.*)$", "^.*$"})
+    public final void parseResourcePatternGlobalWildcard(final String value) {
+        assertThat(ResourcePatternParser.parse(value))
+            .containsExactly(
+                new ResourcePattern(ResourceType.TOPIC, "^.*$", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.GROUP, "^.*$", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.CLUSTER, "^.*$", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.TRANSACTIONAL_ID, "^.*$", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.DELEGATION_TOKEN, "^.*$", PatternType.LITERAL)
+            );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"^Cluster:(.*)$", "^Cluster:.*$"})
+    public final void parseResourcePatternSingleResourceTypeWildcard(final String value) {
+        assertThat(ResourcePatternParser.parse(value))
+            .containsExactly(new ResourcePattern(ResourceType.CLUSTER, ".*", PatternType.LITERAL));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"^TransactionalId:(xxx)$", "^TransactionalId:xxx$"})
+    public final void parseResourcePatternSingleResourceTypeSingleResource(final String value) {
+        assertThat(ResourcePatternParser.parse(value))
+            .containsExactly(new ResourcePattern(ResourceType.TRANSACTIONAL_ID, "xxx", PatternType.LITERAL));
+    }
+
+    @Test
+    public final void parseResourcePatternSingleResourceTypeMultipleResource() {
+        assertThat(ResourcePatternParser.parse("^Topic:(xxx|yyy|bac.*xyz)$"))
+            .containsExactly(
+                new ResourcePattern(ResourceType.TOPIC, "xxx", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.TOPIC, "yyy", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.TOPIC, "bac.*xyz", PatternType.LITERAL)
+            );
+    }
+
+    @Test
+    public final void parseResourcePatternMultipleResourceTypeWildcard() {
+        assertThat(ResourcePatternParser.parse("^(Cluster|Topic):(.*)$"))
+            .containsExactly(
+                new ResourcePattern(ResourceType.CLUSTER, ".*", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.TOPIC, ".*", PatternType.LITERAL)
+            );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"^(Cluster|Topic):(xxx)$", "^(Cluster|Topic):xxx$"})
+    public final void parseResourcePatternMultipleResourceTypeSingleResource(final String value) {
+        assertThat(ResourcePatternParser.parse(value))
+            .containsExactly(
+                new ResourcePattern(ResourceType.CLUSTER, "xxx", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.TOPIC, "xxx", PatternType.LITERAL)
+            );
+    }
+
+    @Test
+    public final void parseResourcePatternMultipleResourceTypeMultipleResource() {
+        assertThat(ResourcePatternParser.parse("^(Cluster|Topic):(xxx|yyy|bac.*xyz)$"))
+            .containsExactly(
+                new ResourcePattern(ResourceType.CLUSTER, "xxx", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.CLUSTER, "yyy", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.CLUSTER, "bac.*xyz", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.TOPIC, "xxx", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.TOPIC, "yyy", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.TOPIC, "bac.*xyz", PatternType.LITERAL)
+            );
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "^(AAA|BBB|CCC|DDD)",
+        "(AAA|BBB|CCC|DDD)$",
+        "^(AAA|BBB|CCC|DDD",
+        "AAA|BBB|CCC|DDD)$",
+        "^Cluster$",
+        "^Cluster:$",
+        "^:xxx$",
+    })
+    public final void parseResourcePatternInvalid(final String pattern) {
+        assertThat(ResourcePatternParser.parse(pattern))
+            .isEmpty();
+    }
+
+    @Test
+    public final void parseResourcePatternNull() {
+        assertThat(ResourcePatternParser.parse(null))
+            .isEmpty();
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/nativeacls/ResourcePatternParserTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nativeacls/ResourcePatternParserTest.java
@@ -32,11 +32,11 @@ public class ResourcePatternParserTest {
     public final void parseResourcePatternGlobalWildcard(final String value) {
         assertThat(ResourcePatternParser.parse(value))
             .containsExactly(
-                new ResourcePattern(ResourceType.TOPIC, "^.*$", PatternType.LITERAL),
-                new ResourcePattern(ResourceType.GROUP, "^.*$", PatternType.LITERAL),
-                new ResourcePattern(ResourceType.CLUSTER, "^.*$", PatternType.LITERAL),
-                new ResourcePattern(ResourceType.TRANSACTIONAL_ID, "^.*$", PatternType.LITERAL),
-                new ResourcePattern(ResourceType.DELEGATION_TOKEN, "^.*$", PatternType.LITERAL)
+                new ResourcePattern(ResourceType.TOPIC, "*", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.GROUP, "*", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.CLUSTER, "*", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.TRANSACTIONAL_ID, "*", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.DELEGATION_TOKEN, "*", PatternType.LITERAL)
             );
     }
 
@@ -44,7 +44,7 @@ public class ResourcePatternParserTest {
     @ValueSource(strings = {"^Cluster:(.*)$", "^Cluster:.*$"})
     public final void parseResourcePatternSingleResourceTypeWildcard(final String value) {
         assertThat(ResourcePatternParser.parse(value))
-            .containsExactly(new ResourcePattern(ResourceType.CLUSTER, ".*", PatternType.LITERAL));
+            .containsExactly(new ResourcePattern(ResourceType.CLUSTER, "*", PatternType.LITERAL));
     }
 
     @ParameterizedTest
@@ -68,8 +68,8 @@ public class ResourcePatternParserTest {
     public final void parseResourcePatternMultipleResourceTypeWildcard() {
         assertThat(ResourcePatternParser.parse("^(Cluster|Topic):(.*)$"))
             .containsExactly(
-                new ResourcePattern(ResourceType.CLUSTER, ".*", PatternType.LITERAL),
-                new ResourcePattern(ResourceType.TOPIC, ".*", PatternType.LITERAL)
+                new ResourcePattern(ResourceType.CLUSTER, "*", PatternType.LITERAL),
+                new ResourcePattern(ResourceType.TOPIC, "*", PatternType.LITERAL)
             );
     }
 
@@ -96,6 +96,22 @@ public class ResourcePatternParserTest {
             );
     }
 
+    @Test
+    public final void parsePrefixResource() {
+        assertThat(ResourcePatternParser.parse("^Topic:(topic.(.*))$"))
+            .containsExactly(
+                new ResourcePattern(ResourceType.TOPIC, "topic.", PatternType.PREFIXED)
+            );
+    }
+
+    @Test
+    public final void parseMultiplePrefixResource() {
+        assertThat(ResourcePatternParser.parse("^Topic:(topic1.(.*)|topic2.(.*))$"))
+            .containsExactly(
+                new ResourcePattern(ResourceType.TOPIC, "topic1.", PatternType.PREFIXED),
+                new ResourcePattern(ResourceType.TOPIC, "topic2.", PatternType.PREFIXED)
+            );
+    }
 
     @ParameterizedTest
     @ValueSource(strings = {

--- a/src/test/java/io/aiven/kafka/auth/nativeacls/ResourceTypeParserTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nativeacls/ResourceTypeParserTest.java
@@ -27,28 +27,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ResourceTypeParserTest {
     @Test
     public final void parseResourceTypeSingle() {
-        assertThat(ResourceTypeParser.parse("^Topic$"))
+        assertThat(ResourceTypeParser.parse("Topic"))
             .containsExactly(ResourceType.TOPIC);
-    }
-
-    @Test
-    public final void parseResourceTypeSingleWithParens() {
-        assertThat(ResourceTypeParser.parse("^(Topic)$"))
-            .containsExactly(ResourceType.TOPIC);
-    }
-
-    @Test
-    public final void parseResourceTypeMultiple() {
-        // List all possible here, apart from Unknown.
-        assertThat(ResourceTypeParser.parse("^(Any|Topic|Group|Cluster|TransactionalId|DelegationToken)$"))
-            .containsExactly(
-                ResourceType.ANY,
-                ResourceType.TOPIC,
-                ResourceType.GROUP,
-                ResourceType.CLUSTER,
-                ResourceType.TRANSACTIONAL_ID,
-                ResourceType.DELEGATION_TOKEN
-            );
     }
 
     @ParameterizedTest
@@ -66,8 +46,8 @@ public class ResourceTypeParserTest {
 
     @Test
     public final void parseResourceTypeUnknown() {
-        assertThat(ResourceTypeParser.parse("^(Some)$"))
-            .isEmpty();
+        assertThat(ResourceTypeParser.parse("Some"))
+            .containsExactly(ResourceType.UNKNOWN);
     }
 
     @Test
@@ -76,21 +56,4 @@ public class ResourceTypeParserTest {
             .isEmpty();
     }
 
-    @Test
-    public final void parseResourceTypeMultipleWithUnknown() {
-        assertThat(ResourceTypeParser.parse("^(Topic|Cluster|Some)$"))
-            .containsExactly(ResourceType.TOPIC, ResourceType.CLUSTER);
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {
-        "^(Topic|Cluster)",
-        "(Topic|Cluster)$",
-        "^(Topic|Cluster",
-        "Topic|Cluster)$"
-    })
-    public final void parseResourceTypeInvalid(final String pattern) {
-        assertThat(ResourceTypeParser.parse(pattern))
-            .isEmpty();
-    }
 }

--- a/src/test/java/io/aiven/kafka/auth/nativeacls/ResourceTypeParserTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nativeacls/ResourceTypeParserTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nativeacls;
+
+import org.apache.kafka.common.resource.ResourceType;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResourceTypeParserTest {
+    @Test
+    public final void parseResourceTypeSingle() {
+        assertThat(ResourceTypeParser.parse("^Topic$"))
+            .containsExactly(ResourceType.TOPIC);
+    }
+
+    @Test
+    public final void parseResourceTypeSingleWithParens() {
+        assertThat(ResourceTypeParser.parse("^(Topic)$"))
+            .containsExactly(ResourceType.TOPIC);
+    }
+
+    @Test
+    public final void parseResourceTypeMultiple() {
+        // List all possible here, apart from Unknown.
+        assertThat(ResourceTypeParser.parse("^(Any|Topic|Group|Cluster|TransactionalId|DelegationToken)$"))
+            .containsExactly(
+                ResourceType.ANY,
+                ResourceType.TOPIC,
+                ResourceType.GROUP,
+                ResourceType.CLUSTER,
+                ResourceType.TRANSACTIONAL_ID,
+                ResourceType.DELEGATION_TOKEN
+            );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"^(.*)$", "^.*$"})
+    public final void parseResourceTypeGlobalWildcard(final String value) {
+        assertThat(ResourceTypeParser.parse(value))
+            .containsExactly(
+                ResourceType.TOPIC,
+                ResourceType.GROUP,
+                ResourceType.CLUSTER,
+                ResourceType.TRANSACTIONAL_ID,
+                ResourceType.DELEGATION_TOKEN
+            );
+    }
+
+    @Test
+    public final void parseResourceTypeUnknown() {
+        assertThat(ResourceTypeParser.parse("^(Some)$"))
+            .isEmpty();
+    }
+
+    @Test
+    public final void parseResourceTypeNull() {
+        assertThat(ResourceTypeParser.parse(null))
+            .isEmpty();
+    }
+
+    @Test
+    public final void parseResourceTypeMultipleWithUnknown() {
+        assertThat(ResourceTypeParser.parse("^(Topic|Cluster|Some)$"))
+            .containsExactly(ResourceType.TOPIC, ResourceType.CLUSTER);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "^(Topic|Cluster)",
+        "(Topic|Cluster)$",
+        "^(Topic|Cluster",
+        "Topic|Cluster)$"
+    })
+    public final void parseResourceTypeInvalid(final String pattern) {
+        assertThat(ResourceTypeParser.parse(pattern))
+            .isEmpty();
+    }
+}

--- a/src/test/resources/test_acls_for_acls_method.json
+++ b/src/test/resources/test_acls_for_acls_method.json
@@ -12,6 +12,24 @@
     "resource": "^Topic:(.*)$"
   },
   {
+    "operation": "^Read$",
+    "principal": "^(test\\-user)$",
+    "principal_type": "User",
+    "resource": "^Topic:(prefix\\.(.*))$"
+  },
+  {
+    "operation": "^Create$",
+    "principal": "^(test\\-admin)$",
+    "principal_type": "User",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "operation": "^Delete$",
+    "principal": "^(test\\-admin)$",
+    "principal_type": "User",
+    "resource": "^Topic:(.*)$"
+  },
+  {
     "operation": "^(.*)$",
     "principal": "^(.*)$",
     "principal_type": "Service",

--- a/src/test/resources/test_acls_for_acls_method.json
+++ b/src/test/resources/test_acls_for_acls_method.json
@@ -1,0 +1,20 @@
+[
+  {
+    "operation": "^(Alter|AlterConfigs|Delete|Read|Write)$",
+    "principal": "^(test\\-user)$",
+    "principal_type": "User",
+    "resource": "^Topic:(xxx)$"
+  },
+  {
+    "operation": "^(Describe|DescribeConfigs)$",
+    "principal": "^(test\\-user)$",
+    "principal_type": "User",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "operation": "^(.*)$",
+    "principal": "^(.*)$",
+    "principal_type": "Service",
+    "resource": "^(.*)$"
+  }
+]


### PR DESCRIPTION
This PR implements the `acls` method from the `org.apache.kafka.server.authorizer.Authorizer` interface, by converting Aiven ACLs into Kafka native ACLs.