### PR TITLE
Bump mockito from 4.11.0 to 5.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ jmh {
 
 ext {
     kafkaVersion = "2.8.0"
+    mockitoVersion = "5.1.1"
 }
 
 dependencies {
@@ -92,8 +93,8 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter:5.9.1"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.2"
 
-    testImplementation "org.mockito:mockito-core:4.11.0"
-    testImplementation "org.mockito:mockito-junit-jupiter:4.11.0"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "org.mockito:mockito-junit-jupiter:$mockitoVersion"
 
     testImplementation "org.hamcrest:hamcrest-library:2.2"
 


### PR DESCRIPTION
Use common `$mockitoVersion` to keep `mockito-core` and `mockito-junit-jupiter` in sync with each other.

Supersedes #113 and #115 