### PR TITLE
Implement ACL permission types

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ used internally in Aiven to map project id from certificate subject into
 project specific management topics. We can thus avoid encoding separate rules
 for each project.
 
+Permission type allows to define the verification result in case of an ACL match.
+By default, the permission type is `ALLOW`.
+
 ### Example
 
     [
@@ -32,7 +35,8 @@ for each project.
             "operation": "^(Describe|DescribeConfigs|Read|Write)$",
             "principal": "^CN=(?<vmname>[a-z0-9-]+),OU=(?<nodeid>n[0-9]+),O=(?<projectid>[a-f0-9-]+),ST=vm$",
             "principal_type": "Prune",
-            "resource_pattern": "^Topic:${projectid}-(.*)",
+            "resource_pattern": "^Topic:${projectid}-(.*),
+            "permission_type": "DENY"
         }
     ]
 

--- a/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerV2.java
+++ b/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerV2.java
@@ -244,7 +244,7 @@ public class AivenAclAuthorizerV2 implements Authorizer {
     @Override
     public final Iterable<AclBinding> acls(final AclBindingFilter filter) {
         if (this.config.listAclsEnabled()) {
-            return this.cacheReference.get().aclEntries().stream()
+            return this.cacheReference.get().aclEntries()
                     .flatMap(acl -> AclAivenToNativeConverter.convert(acl).stream())
                     .filter(filter::matches)
                     .collect(Collectors.toList());

--- a/src/main/java/io/aiven/kafka/auth/VerdictCache.java
+++ b/src/main/java/io/aiven/kafka/auth/VerdictCache.java
@@ -16,44 +16,62 @@
 
 package io.aiven.kafka.auth;
 
+import javax.annotation.Nonnull;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
+import io.aiven.kafka.auth.json.AclPermissionType;
 import io.aiven.kafka.auth.json.AivenAcl;
 
 public class VerdictCache {
-    private final List<AivenAcl> aclEntries;
+    private final List<AivenAcl> allowAclEntries;
+    private final List<AivenAcl> denyAclEntries;
     private final Map<String, Boolean> cache = new ConcurrentHashMap<>();
 
-    private VerdictCache(final List<AivenAcl> aclEntries) {
-        this.aclEntries = aclEntries;
+    private VerdictCache(@Nonnull final List<AivenAcl> denyAclEntries, @Nonnull final List<AivenAcl> allowAclEntries) {
+        this.denyAclEntries = denyAclEntries;
+        this.allowAclEntries = allowAclEntries;
     }
 
     public boolean get(final KafkaPrincipal principal,
                        final String operation,
                        final String resource) {
-        if (aclEntries != null) {
-            final String cacheKey = resource
-                + "|" + operation
-                + "|" + principal.getName()
-                + "|" + principal.getPrincipalType();
-            final Predicate<AivenAcl> matcher = aclEntry ->
-                aclEntry.check(principal.getPrincipalType(), principal.getName(), operation, resource);
-            return cache.computeIfAbsent(cacheKey, key -> aclEntries.stream().anyMatch(matcher));
-        } else {
-            return false;
-        }
+        final String principalType = principal.getPrincipalType();
+        final String cacheKey = resource
+            + "|" + operation
+            + "|" + principal.getName()
+            + "|" + principalType;
+
+        return cache.computeIfAbsent(cacheKey, key -> {
+            final Predicate<AivenAcl> matcher = acl ->
+                acl.match(principalType, principal.getName(), operation, resource);
+            if (denyAclEntries.stream().anyMatch(matcher)) {
+                return false;
+            } else {
+                return allowAclEntries.stream().anyMatch(matcher);
+            }
+        });
     }
 
-    public List<AivenAcl> aclEntries() {
-        return List.copyOf(aclEntries);
+    public Stream<AivenAcl> aclEntries() {
+        return Stream.concat(denyAclEntries.stream(), allowAclEntries.stream());
     }
 
     public static VerdictCache create(final List<AivenAcl> aclEntries) {
-        return new VerdictCache(aclEntries);
+        if (aclEntries == null || aclEntries.isEmpty()) {
+            return new VerdictCache(Collections.emptyList(), Collections.emptyList());
+        }
+
+        final Map<Boolean, List<AivenAcl>> partitionedEntries = aclEntries.stream()
+            .collect(Collectors.partitioningBy(x -> x.getPermissionType() == AclPermissionType.DENY));
+        return new VerdictCache(partitionedEntries.get(true), partitionedEntries.get(false));
     }
 }

--- a/src/main/java/io/aiven/kafka/auth/json/AclPermissionType.java
+++ b/src/main/java/io/aiven/kafka/auth/json/AclPermissionType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.json;
+
+public enum AclPermissionType {
+    ALLOW(org.apache.kafka.common.acl.AclPermissionType.ALLOW),
+    DENY(org.apache.kafka.common.acl.AclPermissionType.DENY);
+
+    public final org.apache.kafka.common.acl.AclPermissionType nativeType;
+
+    AclPermissionType(final org.apache.kafka.common.acl.AclPermissionType nativeType) {
+        this.nativeType = nativeType;
+    }
+}

--- a/src/main/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverter.java
+++ b/src/main/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverter.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
-import org.apache.kafka.common.acl.AclPermissionType;
 
 import io.aiven.kafka.auth.json.AivenAcl;
 
@@ -43,7 +42,7 @@ public class AclAivenToNativeConverter {
             );
             for (final var principal : principals) {
                 final var accessControlEntry = new AccessControlEntry(
-                    principal, "*", operation, AclPermissionType.ALLOW);
+                    principal, "*", operation, aivenAcl.getPermissionType().nativeType);
                 for (final var resourcePattern : ResourcePatternParser.parse(aivenAcl.resourceRe.pattern())) {
                     result.add(new AclBinding(resourcePattern, accessControlEntry));
                 }

--- a/src/test/java/io/aiven/kafka/auth/json/AivenAclTest.java
+++ b/src/test/java/io/aiven/kafka/auth/json/AivenAclTest.java
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.auth;
-
-import io.aiven.kafka.auth.json.AivenAcl;
+package io.aiven.kafka.auth.json;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AivenAclTest {
-
     @Test
     public void testAivenAclEntry() {
         // Basic test: defined principal type plus principal, operation and resource regex
@@ -33,14 +30,15 @@ public class AivenAclTest {
             "^CN=p_(.*)_s$", // principal
             "^(Describe|Read)$", // operation
             "^Topic:p_(.*)_s", // resource,
-            null // resource pattern
+            null, // resource pattern
+            null
         );
 
-        assertTrue(entry.check("User", "CN=p_pass_s", "Read", "Topic:p_pass_s"));
-        assertFalse(entry.check("User", "CN=fail", "Read", "Topic:p_pass_s"));
-        assertFalse(entry.check("User", "CN=p_pass_s", "Write", "Topic:p_pass_s"));
-        assertFalse(entry.check("User", "CN=p_pass_s", "Read", "Topic:fail"));
-        assertFalse(entry.check("NonUser", "CN=p_pass_s", "Read", "Topic:p_pass_s"));
+        assertTrue(entry.match("User", "CN=p_pass_s", "Read", "Topic:p_pass_s"));
+        assertFalse(entry.match("User", "CN=fail", "Read", "Topic:p_pass_s"));
+        assertFalse(entry.match("User", "CN=p_pass_s", "Write", "Topic:p_pass_s"));
+        assertFalse(entry.match("User", "CN=p_pass_s", "Read", "Topic:fail"));
+        assertFalse(entry.match("NonUser", "CN=p_pass_s", "Read", "Topic:p_pass_s"));
 
         // Test with principal undefined
         entry = new AivenAcl(
@@ -48,13 +46,14 @@ public class AivenAclTest {
             "^CN=p_(.*)_s$", // principal
             "^(Describe|Read)$", // operation
             "^Topic:p_(.*)_s", // resource
-            null // resource pattern
+            null, // resource pattern
+            null
         );
 
-        assertTrue(entry.check("User", "CN=p_pass_s", "Read", "Topic:p_pass_s"));
-        assertTrue(entry.check("NonUser", "CN=p_pass_s", "Read", "Topic:p_pass_s"));
-        assertFalse(entry.check("User", "CN=fail", "Read", "Topic:p_pass_s"));
-        assertFalse(entry.check("User", "CN=p_pass_s", "Read", "Topic:fail"));
+        assertTrue(entry.match("User", "CN=p_pass_s", "Read", "Topic:p_pass_s"));
+        assertTrue(entry.match("NonUser", "CN=p_pass_s", "Read", "Topic:p_pass_s"));
+        assertFalse(entry.match("User", "CN=fail", "Read", "Topic:p_pass_s"));
+        assertFalse(entry.match("User", "CN=p_pass_s", "Read", "Topic:fail"));
 
         // Test resources defined by pattern
         entry = new AivenAcl(
@@ -62,12 +61,13 @@ public class AivenAclTest {
             "^CN=p_(?<username>[a-z0-9]+)_s$", // principal
             "^(Describe|Read)$", // operation
             null, // resource
-            "^Topic:p_${username}_s\\$" // resource pattern
+            "^Topic:p_${username}_s\\$", // resource pattern
+            null
         );
 
-        assertTrue(entry.check("User", "CN=p_user1_s", "Read", "Topic:p_user1_s"));
-        assertTrue(entry.check("User", "CN=p_user2_s", "Read", "Topic:p_user2_s"));
-        assertFalse(entry.check("User", "CN=p_user1_s", "Read", "Topic:p_user2_s"));
-        assertFalse(entry.check("User", "CN=p_user2_s", "Read", "Topic:p_user1_s"));
+        assertTrue(entry.match("User", "CN=p_user1_s", "Read", "Topic:p_user1_s"));
+        assertTrue(entry.match("User", "CN=p_user2_s", "Read", "Topic:p_user2_s"));
+        assertFalse(entry.match("User", "CN=p_user1_s", "Read", "Topic:p_user2_s"));
+        assertFalse(entry.match("User", "CN=p_user2_s", "Read", "Topic:p_user1_s"));
     }
 }

--- a/src/test/java/io/aiven/kafka/auth/json/reader/AclJsonReaderTest.java
+++ b/src/test/java/io/aiven/kafka/auth/json/reader/AclJsonReaderTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.json.reader;
+
+import java.io.File;
+
+import io.aiven.kafka.auth.json.AclPermissionType;
+import io.aiven.kafka.auth.json.AivenAcl;
+
+import com.google.gson.JsonParseException;
+import org.junit.jupiter.api.Test;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AclJsonReaderTest {
+
+    @Test
+    public final void parseAcls() {
+        final var path = new File(this.getClass().getResource("/acls_full.json").getPath()).toPath();
+        final var jsonReader = new AclJsonReader(path);
+        final var acls = jsonReader.read();
+        assertThat(acls).containsExactly(
+            new AivenAcl("User", "^pass-3$", "^Read$", "^Topic:denied$", null, AclPermissionType.DENY),
+            new AivenAcl("User", "^pass-0$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-1$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-2$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-3$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-4$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-5$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-6$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-7$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-8$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-9$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-10$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-11$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-12$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl(null, "^pass-notype$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl(
+                "User", "^pass-resource-pattern$", "^Read$", null, "^Topic:${projectid}-(.*)", AclPermissionType.ALLOW
+            )
+        );
+    }
+
+    @Test
+    public final void parseDenyAcl() {
+        final var path = new File(this.getClass().getResource("/test_parse_acl_type.json").getPath()).toPath();
+        final var jsonReader = new AclJsonReader(path);
+        final var acls = jsonReader.read();
+        final var allowAcl = new AivenAcl(
+            "User",
+            "^allow$",
+            "^Read$",
+            "^(.*)$",
+            null,
+            AclPermissionType.ALLOW
+        );
+        final var denyAcl = new AivenAcl(
+            "User",
+            "^deny$",
+            "^Read$",
+            "^(.*)$",
+            null,
+            AclPermissionType.DENY
+        );
+        assertThat(acls).containsExactly(allowAcl, allowAcl, allowAcl, denyAcl, denyAcl);
+    }
+
+    @Test
+    public final void parseWrong() {
+        final var path = new File(this.getClass().getResource("/acl_wrong_permission_type.json").getPath()).toPath();
+        final var jsonReader = new AclJsonReader(path);
+        assertThrows(JsonParseException.class, jsonReader::read);
+    }
+
+}

--- a/src/test/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverterTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverterTest.java
@@ -42,7 +42,8 @@ public class AclAivenToNativeConverterTest {
                 "^(test\\-user)$",
                 "^(Alter|AlterConfigs|Delete|Read|Write)$",
                 "^Topic:(xxx)$",
-                null
+                null,
+                io.aiven.kafka.auth.json.AclPermissionType.ALLOW
             )
         );
         final ResourcePattern resourcePattern = new ResourcePattern(ResourceType.TOPIC, "xxx", PatternType.LITERAL);
@@ -66,6 +67,26 @@ public class AclAivenToNativeConverterTest {
     }
 
     @Test
+    public final void testNullPermissionTypeIsAllow() {
+        final var result = AclAivenToNativeConverter.convert(
+            new AivenAcl(
+                "User",
+                "^(test\\-user)$",
+                "^Read$",
+                "^Topic:(xxx)$",
+                null,
+                null
+            )
+        );
+        final ResourcePattern resourcePattern = new ResourcePattern(ResourceType.TOPIC, "xxx", PatternType.LITERAL);
+        assertThat(result).containsExactly(
+            new AclBinding(
+                resourcePattern,
+                new AccessControlEntry("User:test\\-user", "*", AclOperation.READ, AclPermissionType.ALLOW))
+        );
+    }
+
+    @Test
     public final void testConvertPrefix() {
         final var result = AclAivenToNativeConverter.convert(
             new AivenAcl(
@@ -73,6 +94,7 @@ public class AclAivenToNativeConverterTest {
                 "^(test\\-user)$",
                 "^Read$",
                 "^Topic:(topic\\.(.*))$",
+                null,
                 null
             )
         );
@@ -85,6 +107,26 @@ public class AclAivenToNativeConverterTest {
     }
 
     @Test
+    public final void testDeny() {
+        final var result = AclAivenToNativeConverter.convert(
+            new AivenAcl(
+                "User",
+                "^(test\\-user)$",
+                "^Read$",
+                "^Topic:(topic\\.(.*))$",
+                null,
+                io.aiven.kafka.auth.json.AclPermissionType.DENY
+            )
+        );
+        assertThat(result).containsExactly(
+            new AclBinding(
+                new ResourcePattern(ResourceType.TOPIC, "topic\\.", PatternType.PREFIXED),
+                new AccessControlEntry("User:test\\-user", "*", AclOperation.READ, AclPermissionType.DENY)
+            )
+        );
+    }
+
+    @Test
     public final void testConvertMultiplePrefixes() {
         final var result = AclAivenToNativeConverter.convert(
             new AivenAcl(
@@ -92,6 +134,7 @@ public class AclAivenToNativeConverterTest {
                 "^(test\\-user)$",
                 "^(Delete|Read|Write)$",
                 "^Topic:(topic\\.(.*)|prefix\\-(.*))$",
+                null,
                 null
             )
         );
@@ -131,6 +174,7 @@ public class AclAivenToNativeConverterTest {
                 "^(admin)$",
                 "^(.*)$",
                 "^(.*)$",
+                null,
                 null
             )
         );
@@ -163,6 +207,7 @@ public class AclAivenToNativeConverterTest {
                 "^(.*)$",
                 "^Read$",
                 "^Topic:(xxx)$",
+                null,
                 null
             )
         );
@@ -183,6 +228,7 @@ public class AclAivenToNativeConverterTest {
                 "^example$",
                 "^Read$",
                 "^Topic:(xxx)$",
+                null,
                 null
             )
         );

--- a/src/test/resources/acl_wrong_permission_type.json
+++ b/src/test/resources/acl_wrong_permission_type.json
@@ -1,0 +1,9 @@
+[
+  {
+    "principal_type": "User",
+    "principal": "^p$",
+    "operation": "^Read$",
+    "resource": "^(.*)$",
+    "permission_type": "wrong"
+  }
+]

--- a/src/test/resources/acls_deny.json
+++ b/src/test/resources/acls_deny.json
@@ -1,0 +1,16 @@
+[
+  {
+    "principal_type": "User",
+    "principal": "^(.*)$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$",
+    "permission_type": "ALLOW"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^(.*)$",
+    "operation": "^Read$",
+    "resource": "^Topic:(topic-denied)$",
+    "permission_type": "DENY"
+  }
+]

--- a/src/test/resources/acls_deny_prefix.json
+++ b/src/test/resources/acls_deny_prefix.json
@@ -1,0 +1,15 @@
+[
+  {
+    "principal_type": "User",
+    "principal": "^(.*)$",
+    "operation": "^(.*)$",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^(.*)$",
+    "operation": "^Create",
+    "resource": "^Topic:denied-(.*)$",
+    "permission_type": "DENY"
+  }
+]

--- a/src/test/resources/acls_full.json
+++ b/src/test/resources/acls_full.json
@@ -1,0 +1,98 @@
+[
+  {
+    "principal_type": "User",
+    "principal": "^pass-3$",
+    "operation": "^Read$",
+    "resource": "^Topic:denied$",
+    "permission_type": "DENY"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^pass-0$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^pass-1$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^pass-2$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^pass-3$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^pass-4$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^pass-5$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^pass-6$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^pass-7$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^pass-8$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^pass-9$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^pass-10$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^pass-11$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^pass-12$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "principal": "^pass-notype$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^pass-resource-pattern$",
+    "operation": "^Read$",
+    "resource_pattern": "^Topic:${projectid}-(.*)"
+  }
+]

--- a/src/test/resources/acls_no_type.json
+++ b/src/test/resources/acls_no_type.json
@@ -1,0 +1,7 @@
+[
+  {
+    "principal": "^pass$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  }
+]

--- a/src/test/resources/acls_plain.json
+++ b/src/test/resources/acls_plain.json
@@ -1,0 +1,8 @@
+[
+  {
+    "principal_type": "User",
+    "principal": "^pass$",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  }
+]

--- a/src/test/resources/acls_topic_prefix.json
+++ b/src/test/resources/acls_topic_prefix.json
@@ -1,0 +1,8 @@
+[
+  {
+    "principal_type": "User",
+    "principal": "^pass$",
+    "operation": "^Read$",
+    "resource": "^Topic:(prefix-(.*))$"
+  }
+]

--- a/src/test/resources/test_parse_acl_type.json
+++ b/src/test/resources/test_parse_acl_type.json
@@ -1,0 +1,37 @@
+[
+  {
+    "principal_type": "User",
+    "principal": "^allow$",
+    "operation": "^Read$",
+    "resource": "^(.*)$",
+    "permission_type": null
+  },
+  {
+    "principal_type": "User",
+    "principal": "^allow$",
+    "operation": "^Read$",
+    "resource": "^(.*)$",
+    "permission_type": "ALLOW"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^allow$",
+    "operation": "^Read$",
+    "resource": "^(.*)$",
+    "permission_type": "allow"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^deny$",
+    "operation": "^Read$",
+    "resource": "^(.*)$",
+    "permission_type": "DENY"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^deny$",
+    "operation": "^Read$",
+    "resource": "^(.*)$",
+    "permission_type": "deny"
+  }
+]


### PR DESCRIPTION
Introduce the concept of ACL permission types: an ACL can represent an allow rule or a deny rule.
Deny ACLs behave like blocklist and they have precedence during the evaluation of a request. Allow ACLs behave like allowlist and are checked only if there's no Deny ACL that denies the request.